### PR TITLE
Add zlog APIs along with dzlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             # wc /tmp/spdlog*
             # wc /tmp/zlog*
             # echo
-            rm /tmp/{spdlog,zlog}*
+            rm /tmp/{spdlog,zlog,dzlog}*
           done
         } | tee -a "$GITHUB_STEP_SUMMARY"
         echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
     - name: Checkout [${{ github.repository }}]
       uses: actions/checkout@v4
       with:
-        ref: main
         submodules: true
 
     - name: Build zlog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout [${{ github.repository }}]
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: main
         submodules: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ spdlog vs zlog benchmarks
 
 - [spdlog 1.12.0](https://github.com/gabime/spdlog/releases/tag/v1.12.0)
 - [zlog 1.2.16](https://github.com/HardySimpson/zlog/releases/tag/1.2.16)
+  - Both [`zlog_*`](https://hardysimpson.github.io/zlog/UsersGuide-EN.html#htoc28)
+    and [`dzlog_*`](https://hardysimpson.github.io/zlog/UsersGuide-EN.html#htoc33)
+    APIs are benchmarked.
+  - See [zlog.conf](zlog.conf) and [dzlog.conf](dzlog.conf) for their
+    respective configurations.
 
 Tested on Linux and macOS runners via CI. See the most recent run under
 [Actions](https://github.com/iamazeem/spdlog-vs-zlog/actions) tab for the latest
@@ -61,9 +66,28 @@ make
 ```shell
 $ cd build
 $ ./spdlog-vs-zlog
-[2024-01-25 11:05:39.364] [info] threads: 10, iterations: 100,000 per thread
-[2024-01-25 11:05:40.185] [info] spdlog, elapsed time:   0.82 secs, logs/sec:    121,856/sec
-[2024-01-25 11:05:42.300] [info]   zlog, elapsed time:   2.11 secs, logs/sec:     47,292/sec
+[2024-02-06 15:05:17.122] [info] threads: 10, iterations: 100,000 per thread
+[2024-02-06 15:05:18.910] [info] spdlog, elapsed time:   1.79 secs, logs/sec:     55,925/sec
+[2024-02-06 15:06:46.941] [info]   zlog, elapsed time:  88.03 secs, logs/sec:      1,135/sec
+[2024-02-06 15:08:13.512] [info]  dzlog, elapsed time:  86.57 secs, logs/sec:      1,155/sec
+```
+
+The rotated log files are generated under `/tmp` directory:
+
+```shell
+ls /tmp/{spdlog,zlog,dzlog}*
+```
+
+The [CI workflow](.github/workflows/ci.yml) removes these log files after each
+iteration:
+
+```shell
+for i in {1..5}; do
+    echo "Run $i"
+    ./spdlog-vs-zlog
+    echo
+    rm /tmp/{spdlog,zlog,dzlog}*
+done
 ```
 
 ## License

--- a/dzlog.conf
+++ b/dzlog.conf
@@ -1,0 +1,8 @@
+[global]
+strict init = true
+
+[formats]
+format = "%d(%Y-%m-%d %T).%ms %v [%p:%t] %m%n"
+
+[rules]
+*.* "/tmp/dzlog", 10M * 5 ; format


### PR DESCRIPTION
Currently, only the dzlog APIs are being used.
Add zlog APIs as well.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>